### PR TITLE
Remove smtp config for feedback form

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -73,18 +73,6 @@ S3_SECRET_KEY= #optional, default IAM
 S3_SECURE=1 #optional, default uses a secure TLS connection
 
 # ------------------------------------------------------------------------- #
-# SMTP configuration (feedback form). Use `host.docker.internal` if you     #
-# want to connect to a service on this Docker host.                         #
-# ------------------------------------------------------------------------- #
-SMTP_SENDER=
-SMTP_PASSWORD= #optional
-SMTP_RECIPIENTS=
-SMTP_SERVER=
-SMTP_PORT=25 #optional
-SMTP_TLS=0 #optional
-SMTP_STARTTLS=0 #optional
-
-# ------------------------------------------------------------------------- #
 # Optional cron expression in 6 fields (rather than the traditional 5)      #
 # which defines when and how often to check for new releases. If not set,   #
 # the containers won't update automatically.                                #

--- a/README.md
+++ b/README.md
@@ -69,18 +69,6 @@ minio:
   command: minio server /home/shared
 ```
 
-### SMTP Server (optional)
-
-In order to be able to send feedbacks and bug reports from within the Bohrdatenmanagementsystem a SMTP server must be configured. For testing purposes you can spin up a dockerized email testing tool.
-
-```yml
-mailhog:
-  image: mailhog/mailhog
-  ports:
-    - 1025:1025 # SMTP server address
-    - 8025:8025 # web-interface / admin console
-```
-
 ## Automatic Container Updates
 
 Bohrdatenmanagementsystem Docker containers automatically get updated with [Watchtower](https://containrrr.dev/watchtower/). If a new image gets pushed to the registry Watchtower will automatically spin up a new container with the same options that were used when it was deployed initially. Refer to the [dotenv](./.env.template) for scheduling options.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,14 +55,6 @@ services:
       - S3_ACCESS_KEY
       - S3_SECRET_KEY
       - S3_SECURE
-      - SMTP_SENDER
-      - SMTP_PASSWORD
-      - SMTP_RECIPIENTS
-      - SMTP_SERVER
-      - SMTP_PORT
-      - SMTP_TLS
-      - SMTP_STARTTLS
-      - APP_BASE_DOMAIN=${BASE_DOMAIN}
       - TZ
   maintenance:
     image: docker

--- a/kubernetes-manifests/deployments/api-legacy.yaml
+++ b/kubernetes-manifests/deployments/api-legacy.yaml
@@ -78,50 +78,6 @@ spec:
                   name: boreholes
                   key: S3_SECURE
                   optional: true
-            - name: SMTP_SENDER
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_SENDER
-            - name: SMTP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_PASSWORD
-                  optional: true
-            - name: SMTP_RECIPIENTS
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_RECIPIENTS
-            - name: SMTP_SERVER
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_SERVER
-            - name: SMTP_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_PORT
-                  optional: true
-            - name: SMTP_TLS
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_TLS
-                  optional: true
-            - name: SMTP_STARTTLS
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: SMTP_STARTTLS
-                  optional: true
-            - name: APP_BASE_DOMAIN
-              valueFrom:
-                secretKeyRef:
-                  name: boreholes
-                  key: BASE_DOMAIN
             - name: TZ
               valueFrom:
                 secretKeyRef:

--- a/kubernetes-manifests/secrets/boreholes.template.yaml
+++ b/kubernetes-manifests/secrets/boreholes.template.yaml
@@ -47,17 +47,6 @@ stringData:
   #S3_SECURE: '1' #optional, default uses a secure TLS connection
 
   # ------------------------------------------------------------------------- #
-  # SMTP configuration (feedback form)                                        #
-  # ------------------------------------------------------------------------- #
-  SMTP_SENDER:
-  SMTP_RECIPIENTS:
-  SMTP_SERVER:
-  #SMTP_PASSWORD: #optional
-  #SMTP_PORT: '25' #optional
-  #SMTP_TLS: '0' #optional
-  #SMTP_STARTTLS: '0' #optional
-
-  # ------------------------------------------------------------------------- #
   # The default timezone to use for all containers                            #
   # ------------------------------------------------------------------------- #
   TZ: Europe/Zurich


### PR DESCRIPTION
Wird nach dem Rückbau der [Feedback Funktion](https://github.com/geoadmin/suite-bdms/issues/1024) nicht mehr gebraucht.