### PR TITLE
Fix invalid configmap map key

### DIFF
--- a/charts/swissgeol-boreholes-extern-sync/Chart.yaml
+++ b/charts/swissgeol-boreholes-extern-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: swissgeol-boreholes-extern-sync
 description: Synchronizes selected drilling data between a source and a target database.
 type: application
-version: 0.1.10
+version: 0.1.11
 icon: https://raw.githubusercontent.com/swisstopo/swissgeol-boreholes-suite/main/src/client/public/favicon.ico
 appVersion: "v2.1.870"
 home: https://www.swissgeol.ch/en

--- a/charts/swissgeol-boreholes-view-sync/Chart.yaml
+++ b/charts/swissgeol-boreholes-view-sync/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: swissgeol-boreholes-view-sync
 description: Synchronizes freely available drilling data from a source database to a target database.
 type: application
-version: 0.2.16
+version: 0.2.17
 icon: https://raw.githubusercontent.com/swisstopo/swissgeol-boreholes-suite/main/src/client/public/favicon.ico
 appVersion: "v2.1.870"
 home: https://www.swissgeol.ch/en

--- a/charts/swissgeol-boreholes/Chart.yaml
+++ b/charts/swissgeol-boreholes/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: swissgeol-boreholes
 description: Borehole Data Management System
 type: application
-version: 0.7.3
+version: 0.7.4
 icon: https://raw.githubusercontent.com/swisstopo/swissgeol-boreholes-suite/main/src/client/public/favicon.ico
 appVersion: "v2.1.870"
 home: https://www.swissgeol.ch/en

--- a/charts/swissgeol-boreholes/templates/configmap.yaml
+++ b/charts/swissgeol-boreholes/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   s3Endpoint: {{ .Values.s3.endpoint }}
   s3Bucket: {{ .Values.s3.bucket }}
   s3PhotosBucket: {{ .Values.s3.photosBucket }}
-  s3LogFilesBucket: { { .Values.s3.logFilesBucket } }
+  s3LogFilesBucket: {{ .Values.s3.logFilesBucket }}
   s3Secure: {{ .Values.s3.secure | default "1" | quote }}
   authAuthority: {{ .Values.auth.authority | quote }}
   authAudience: {{ .Values.auth.audience | quote }}


### PR DESCRIPTION
An invalid map key leads to the following error when trying to deploy the chart:

```
Error: UPGRADE FAILED: YAML parse error on swissgeol-boreholes/templates/configmap.yaml:
error converting YAML to JSON:
yaml: invalid map key: map[interface {}]interface {}{".Values.s3.logFilesBucket":interface {}(nil)}
```